### PR TITLE
doas should keepenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x &&\
     adduser -G $GNAME -D $UNAME &&\
 
 # Allow $UNAME to sudo/doas as root
-    echo "permit nopass $UNAME" >> /etc/doas.d/$UNAME.conf &&\
+    echo "permit nopass keepenv $UNAME" >> /etc/doas.d/$UNAME.conf &&\
     echo "permit nopass 0" >> /etc/doas.d/root.conf
 
 USER $UNAME


### PR DESCRIPTION
https://man.archlinux.org/man/doas.conf.5.en#keepenv

before
```
~ $ sudo env
DOAS_USER=defaultuser
HOME=/root
LOGNAME=root
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
SHELL=/bin/ash
TERM=xterm
USER=root
```

after
```
~ $ sudo env
DOAS_USER=defaultuser
GID=1000
GNAME=defaultgroup
HOME=/root
HOSTNAME=cb495ba0959e
LOGNAME=root
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/home/defaultuser
SHELL=/bin/ash
SHLVL=2
SUDO_GID=1000
SUDO_UID=1000
SUDO_USER=defaultuser
TERM=xterm
UNAME=defaultuser
USER=root
```